### PR TITLE
Optoma projector bugfix

### DIFF
--- a/lib/pjlink.js
+++ b/lib/pjlink.js
@@ -21,7 +21,7 @@ module.exports = function (host, port, password,command, cb) {
 
    socket.on('data', function(message)
        {
-       message = message.toString('utf8').trim();
+       message = message.toString('utf8').trim().toUpperCase();
        switch (message.substring(0, 8))
        {
            case 'PJLINK 1': //Auth

--- a/lib/pjlink.js
+++ b/lib/pjlink.js
@@ -21,8 +21,8 @@ module.exports = function (host, port, password,command, cb) {
 
    socket.on('data', function(message)
        {
-       message = message.toString('utf8').trim().toUpperCase();
-       switch (message.substring(0, 8))
+       message = message.toString('utf8').trim();
+       switch (message.substring(0, 8).toUpperCase())
        {
            case 'PJLINK 1': //Auth
                var pwtoken = message.substring(9, 17);
@@ -40,8 +40,10 @@ module.exports = function (host, port, password,command, cb) {
        // Debug
        // console.log("Device response: " + message);
 
-       var resultCode = message.substring(message.indexOf('=') + 1)
-                           .substring(message.indexOf(' ') + 1);
+       var resultCode = message
+                            .substring(message.indexOf('=') + 1)
+                            .substring(message.indexOf(' ') + 1)
+                            .toUpperCase();
 
        var resultMessages = {
            OK:   'Successful execution',

--- a/main.js
+++ b/main.js
@@ -115,7 +115,7 @@ function main() {
 
  // Check communication
   pjlink(host,port,password,"%1POWR ?", function (result) {
-   if (result.substring(0,5) == 'Error') {
+   if (result.substring(0,5).toUpperCase() === 'ERROR') {
       adapter.log.error (result);
       adapter.terminate ? adapter.terminate() : process.exit();
      }
@@ -238,7 +238,7 @@ function main() {
 
   // Device Input Source
                 pjlink(host,port,password, "%1INPT ?", function(result){
-                  if (result == 'ERR2') {
+                  if (result.toUpperCase() === 'ERR2') {
                     inputSource = 0;
                     adapter.log.warn('warning: no signal for input source');
                     adapter.setState('inputSource', {val: 'none', ack: true});
@@ -329,11 +329,11 @@ var pollinfo = setInterval(function () {
             pjlink(host,port,password, "%1INPT ?", function(result){
             adapter.log.debug('current device inputSource: ' + result);
             adapter.getState ('inputSource', function (err, adapter_state) {
-              if (result == 'ERR2' && adapter_state.val != 'none') {
+              if (result.toUpperCase() === 'ERR2' && adapter_state.val !== 'none') {
                  inputSource = 0
                  adapter.setState('inputSource', {val: 'none', ack: false});
                 }
-              if (result != 'ERR2' && adapter_state.val != result) {
+              if (result.toUpperCase() !== 'ERR2' && adapter_state.val !== result) {
                  inputSource = result
                  adapter.setState('inputSource', {val: result, ack: false});
                 }


### PR DESCRIPTION
This is a bugfix/ improvement to also support Optoma projectors.
In the original version of this adapter the handshake response from the projector (PJLINK 0 or PJLINK 1) to determine wether a password is needed or not is expected in capital letters. Optoma projectors are responding in lowercase. The PJLink specification says that both variants are ok. To create compatibility to all projectors which are sending responses in lowercase I've added some case-casting to all technical answers of the projector.

This Bugfix adresses the issue #13 